### PR TITLE
Add linting checks using GitHub actions

### DIFF
--- a/.github/workflows/cichecks.yml
+++ b/.github/workflows/cichecks.yml
@@ -11,3 +11,4 @@ jobs:
       - uses: DavidAnson/markdownlint-cli2-action@v9
         with:
           command: fix
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/cichecks.yml
+++ b/.github/workflows/cichecks.yml
@@ -1,3 +1,5 @@
+name: CI Checks
+
 on:
   push:
     branches: ["master"]

--- a/.github/workflows/cichecks.yml
+++ b/.github/workflows/cichecks.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DavidAnson/markdownlint-cli2-action@v9
+        with:
+          command: fix

--- a/.github/workflows/cichecks.yml
+++ b/.github/workflows/cichecks.yml
@@ -14,3 +14,5 @@ jobs:
         with:
           command: fix
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/workflows/markdown-links-config.json

--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,0 +1,10 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.go-fair.org/fair-principles/"
+    },
+    {
+      "pattern": "^mailto:"
+    }
+  ]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "line-length": false,
+  "no-bare-urls": false,
+  "no-multiple-blanks": true
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ISIS Neutron and Muon Source Data Policy
 
-This is a Github reposity for editing, updating and keeping revisions of the ISIS Data Policy.
+This is a Github repository for tracking revisions of the ISIS Data Policy.
 
-Available from the ISIS website from https://www.isis.stfc.ac.uk/Pages/Data-Policy.aspx .
+The latest version is available on the ISIS website from https://www.isis.stfc.ac.uk/Pages/Data-Policy.aspx.
+
 ## Working With The Repository
 
 It is recommended that [Visual Studio Code](https://code.visualstudio.com/)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This is a Github reposity for editing, updating and keeping revisions of the ISIS Data Policy.
 
 Available from the ISIS website from https://www.isis.stfc.ac.uk/Pages/Data-Policy.aspx .
+## Working With The Repository
+
+It is recommended that [Visual Studio Code](https://code.visualstudio.com/)
+with the [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+extension be used to edit the policy. If `Format on Save` is enabled then the
+extension will automatically fix any issues with the document such as extraneous
+whitespace or bare external links.
+
+A [GitHub Action workflow](./.github/workflows/cichecks.yml) is defined to check
+the documents when opening a pull request or pushing to the default branch.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ It is recommended that [Visual Studio Code](https://code.visualstudio.com/)
 with the [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
 extension be used to edit the policy. If `Format on Save` is enabled then the
 extension will automatically fix any issues with the document such as extraneous
-whitespace or bare external links.
-
-A [GitHub Action workflow](./.github/workflows/cichecks.yml) is defined to check
+whitespace or bare external links. This check is also part of a
+[GitHub Action workflow](./.github/workflows/cichecks.yml) check
 the documents when opening a pull request or pushing to the default branch.
+
+The action also has an additional check for dead external links using
+[markdown-link-check](https://github.com/marketplace/actions/markdown-link-check).

--- a/data_policy.md
+++ b/data_policy.md
@@ -1,9 +1,8 @@
-# ISIS Data Policy  
+# ISIS Data Policy
 
 This policy describes how ISIS handles curation, access, ownership, usage, and storage of data collected at the facility, along with the responsibilities users of ISIS have pertaining to these topics.
 
 ISIS is committed to the principles of [FAIR data](https://www.go-fair.org/fair-principles/) in order to support research, and the advancement of knowledge and technology. We release data in common, accessible formats under a permissive Creative Commons license, along with detailed metadata in a variety of human and machine readable formats.
-
 
 ## ISIS data management policy
 
@@ -92,7 +91,6 @@ and the [ISIS Privacy Policy](https://www.isis.stfc.ac.uk/Pages/Privacy.aspx)), 
 
 3.6.5 The on-line catalogue will enable the linking of experimental data to experimental proposals.  Access to proposals will only ever be provided to the experimental team and appropriate STFC staff, unless otherwise authorized by the PI (with the exception of those parts of the online proposal which are flagged as publicly accessible within the proposal system).
 
-
 ### 4. Result data
 
 4.1 Ownership of result data
@@ -111,7 +109,6 @@ and the [ISIS Privacy Policy](https://www.isis.stfc.ac.uk/Pages/Privacy.aspx)), 
 
 4.3.1 Access to the result data of analyses performed on raw data and metadata is restricted to the person or persons performing the analyses, unless otherwise requested by those persons.
 
-
 ### 5. Good practice for metadata capture and result data storage
 
 5.1 The experimental team is encouraged to ensure that experimental metadata are as complete as possible, as this will enhance the possibilities for them to search for, retrieve and interpret their own data in the future.
@@ -121,7 +118,6 @@ and the [ISIS Privacy Policy](https://www.isis.stfc.ac.uk/Pages/Privacy.aspx)), 
 5.3 Researchers who aim to carry out analyses of ISIS data made available after the embargo period should, in addition to citing the data DOI also, where possible, contact the original PI to inform them and suggest a collaboration if appropriate.
 
 5.4 PIs and researchers are encouraged to make result data they generate open access, and to link such data to available ISIS data DOIs.
-
 
 ### 6. Publication information
 


### PR DESCRIPTION
Adds a GitHub action workflow to lint the markdown documents for basic errors when opening a pull request or pushing to the default branch.