### PR TITLE
Update markdown link check action in CI workflow

### DIFF
--- a/.github/workflows/cichecks.yml
+++ b/.github/workflows/cichecks.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           command: fix
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: tcort/github-action-markdown-link-check@v1
         with:
           config-file: .github/workflows/markdown-links-config.json


### PR DESCRIPTION
The original action was deprecated.